### PR TITLE
Désactive la traduction automatique du navigateur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ release GitHub.
 
 ---
 
+## [1.3.1] — 2026-08-10
+
+### Corrigé
+
+- **Libellés métier altérés par la traduction automatique du navigateur** — fiche
+  [#26](https://github.com/adam-labbane/Darzitouna/issues/26), signalée par un
+  utilisateur pilote. Sur une tablette dont la traduction automatique de Chrome
+  était active, des libellés étaient réécrits — « Stocks » devenait « Actions » —
+  la détection de langue étant trompée par des termes ambigus. La page se déclarait
+  en anglais (`<html lang="en">`, valeur héritée du gabarit de départ) alors que
+  l'interface est en français, ce qui déclenchait la proposition de traduction. La
+  langue est désormais correctement déclarée et la traduction automatique est
+  refusée, par l'attribut standard `translate="no"` et par la balise `notranslate`
+  pour Google Traduction. Le besoin sous-jacent des utilisateurs arabophones sera
+  traité par l'internationalisation FR/AR prévue, non par la traduction machine.
+
+---
+
 ## [1.3.0] — 2026-08-10
 
 Version de maintenance : supervision, fiabilisation de la chaîne de livraison et
@@ -175,6 +193,7 @@ Première mise en production.
 
 ---
 
+[1.3.1]: https://github.com/adam-labbane/Darzitouna/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/adam-labbane/Darzitouna/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/adam-labbane/Darzitouna/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/adam-labbane/Darzitouna/compare/v1.1.0...v1.2.0

--- a/index.html
+++ b/index.html
@@ -1,10 +1,16 @@
 <!doctype html>
-<html lang="en">
+<html lang="fr" translate="no">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="theme-color" content="#2D6A4F" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Traduction automatique refusée : elle altérait les libellés métier
+         (« Stocks » rendu en « Actions »). L'attribut translate="no" sur la
+         racine est la forme standard ; cette balise couvre Google Traduction.
+         Le besoin arabophone relève de l'i18n FR/AR, pas de la traduction
+         machine — ne pas retirer sans elle. -->
+    <meta name="google" content="notranslate" />
     <title>dar-zitouna</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dar-zitouna",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dar-zitouna",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@sentry/react": "^10.70.0",
         "@supabase/supabase-js": "^2.111.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dar-zitouna",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Fiche #26 : sur une tablette avec la traduction automatique de Chrome active, des libellés métier étaient réécrits (« Stocks » rendu en « Actions »), la détection de langue étant trompée par des termes ambigus.

La page se déclarait en anglais — lang="en" hérité du gabarit Vite — alors que l'interface est en français, ce qui déclenchait la proposition de traduction. La langue est corrigée et la traduction refusée par translate="no" sur la racine, forme standard honorée par Safari, Firefox et Edge, complétée de la balise notranslate pour Google Traduction.

Le besoin des utilisateurs arabophones sera traité par l'i18n FR/AR, pas par la traduction machine.