### PR TITLE
Corrige les listes non rafraîchies après mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,33 @@ release GitHub.
 
 ---
 
+## [1.3.2] — 2026-08-10
+
+### Corrigé
+
+- **Listes non rafraîchies après création, modification ou suppression** — fiche
+  [#29](https://github.com/adam-labbane/Darzitouna/issues/29), constatée en
+  production sur la création d'un client. L'enregistrement réussissait en base et la
+  modale se fermait, mais la liste continuait d'afficher l'état antérieur : le
+  nouveau client n'apparaissait qu'après un rechargement manuel, au risque que
+  l'utilisateur croie à un échec et saisisse deux fois.
+
+  La cause ne se trouvait pas dans les écrans — tous rappellent bien leurs données
+  après mutation — mais dans la stratégie de cache du service worker. Les lectures
+  `GET /rest/v1/` étaient servies en `StaleWhileRevalidate` : la réponse en cache
+  était renvoyée immédiatement et la revalidation n'intervenait qu'en arrière-plan.
+  La relecture déclenchée juste après une écriture recevait donc l'état d'avant
+  celle-ci. Le défaut était systémique et concernait tous les écrans à liste, la
+  consultation hors ligne masquant simplement le problème le reste du temps.
+
+  La stratégie passe en `NetworkFirst` avec un délai réseau de 3 secondes : en
+  ligne, les données affichées sont toujours fraîches ; hors ligne ou sur réseau
+  trop lent, la dernière réponse connue reste servie, la consultation hors ligne est
+  donc préservée. Un test de non-régression verrouille en outre le contrat côté
+  application : la liste des clients est relue après création.
+
+---
+
 ## [1.3.1] — 2026-08-10
 
 ### Corrigé
@@ -193,6 +220,7 @@ Première mise en production.
 
 ---
 
+[1.3.2]: https://github.com/adam-labbane/Darzitouna/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/adam-labbane/Darzitouna/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/adam-labbane/Darzitouna/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/adam-labbane/Darzitouna/compare/v1.2.0...v1.2.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dar-zitouna",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dar-zitouna",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@sentry/react": "^10.70.0",
         "@supabase/supabase-js": "^2.111.0",
@@ -22,6 +22,7 @@
         "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.3.3",
         "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.3",
         "@types/node": "^26.1.2",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.14",
@@ -3302,6 +3303,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
+      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@trickfilm400/rollup-plugin-off-main-thread": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dar-zitouna",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.3.2",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -26,6 +26,7 @@
     "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.3.3",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.3",
     "@types/node": "^26.1.2",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^19.2.14",

--- a/src/tests/dom/clientsListRefresh.test.tsx
+++ b/src/tests/dom/clientsListRefresh.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router";
+import ClientsList from "../../pages/ClientsList";
+import { createClient, getClients } from "../../lib/clients";
+
+/**
+ * Non-régression de la fiche #29 : après une création réussie, la liste
+ * affichée doit refléter le nouveau client sans rechargement manuel.
+ *
+ * Le défaut d'origine venait de la stratégie de cache du service worker, pas
+ * de ce composant. Ce test verrouille le contrat côté application — la liste
+ * est bien resynchronisée après mutation — pour qu'une refonte du flux ne
+ * réintroduise pas le symptôme par un autre chemin.
+ */
+
+vi.mock("../../lib/supabase", () => ({ supabase: {} }));
+
+vi.mock("../../lib/session", () => ({
+  getHuilerieId: () => "huilerie-test",
+  getCurrentUser: () => ({ id: "u1", nom_complet: "Test", role: "GERANT" }),
+}));
+
+vi.mock("../../lib/clientProfile", () => ({
+  getAllClientsFinancials: () => Promise.resolve({}),
+}));
+
+vi.mock("../../lib/clients", () => ({
+  getClients: vi.fn(),
+  createClient: vi.fn(),
+  archiveClient: vi.fn(),
+}));
+
+const NOUVEAU_CLIENT = {
+  id: "c-1",
+  nom_complet: "Salah Ben Youssef",
+  telephone: "20123456",
+  solde_compte: 0,
+};
+
+beforeEach(() => {
+  vi.mocked(createClient).mockResolvedValue(NOUVEAU_CLIENT as never);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+function renderListe() {
+  return render(
+    <MemoryRouter>
+      <ClientsList />
+    </MemoryRouter>,
+  );
+}
+
+describe("rafraîchissement de la liste des clients", () => {
+  it("affiche le client créé sans rechargement de la page", async () => {
+    // La liste est vide au montage, puis contient le client après création :
+    // c'est exactement la séquence que le cache périmé faisait échouer.
+    vi.mocked(getClients)
+      .mockResolvedValueOnce([])
+      .mockResolvedValue([NOUVEAU_CLIENT as never]);
+
+    const user = userEvent.setup();
+    renderListe();
+
+    expect(await screen.findByText("Aucun client")).toBeDefined();
+
+    await user.click(screen.getByRole("button", { name: "Nouveau client" }));
+    await user.type(screen.getByLabelText(/Nom complet/i), NOUVEAU_CLIENT.nom_complet);
+    await user.click(screen.getByRole("button", { name: "Créer" }));
+
+    expect(await screen.findByText(NOUVEAU_CLIENT.nom_complet)).toBeDefined();
+  });
+
+  it("relit la liste après la création, sans se contenter de fermer la modale", async () => {
+    vi.mocked(getClients).mockResolvedValue([]);
+
+    const user = userEvent.setup();
+    renderListe();
+    await screen.findByText("Aucun client");
+
+    const lecturesAvant = vi.mocked(getClients).mock.calls.length;
+
+    await user.click(screen.getByRole("button", { name: "Nouveau client" }));
+    await user.type(screen.getByLabelText(/Nom complet/i), NOUVEAU_CLIENT.nom_complet);
+    await user.click(screen.getByRole("button", { name: "Créer" }));
+
+    await waitFor(() => {
+      expect(vi.mocked(createClient)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(getClients).mock.calls.length).toBeGreaterThan(lecturesAvant);
+    });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -45,9 +45,18 @@ export default defineConfig({
           {
             urlPattern: ({ url }) => url.pathname.startsWith('/rest/v1/'),
             method: 'GET',
-            handler: 'StaleWhileRevalidate',
+            // NetworkFirst et non StaleWhileRevalidate : ce dernier renvoyait
+            // immédiatement la réponse en cache et ne revalidait qu'en arrière-plan.
+            // Une liste rechargée juste après une création affichait donc l'état
+            // d'AVANT la mutation, et le nouvel enregistrement n'apparaissait
+            // qu'au rechargement suivant — au risque que l'utilisateur croie à un
+            // échec et saisisse deux fois.
+            // Le cache reste un filet de sécurité hors ligne : au-delà du délai
+            // réseau, ou sans réseau du tout, la dernière réponse connue est servie.
+            handler: 'NetworkFirst',
             options: {
               cacheName: 'supabase-data',
+              networkTimeoutSeconds: 3,
               expiration: {
                 maxEntries: 200,
                 maxAgeSeconds: 7 * 24 * 60 * 60,


### PR DESCRIPTION
Fiche #29 : après création d'un client, l'enregistrement réussissait en base et la modale se fermait, mais la liste continuait d'afficher l'état antérieur — le client n'apparaissait qu'après un rechargement manuel, au risque d'une double saisie.

La cause n'était pas dans les écrans : tous rappellent bien leurs données après mutation. Elle était dans le service worker, qui servait les lectures GET /rest/v1/ en StaleWhileRevalidate — réponse en cache renvoyée immédiatement, revalidation en arrière-plan seulement. La relecture déclenchée juste après une écriture recevait donc l'état d'avant celle-ci, sur tous les écrans à liste.

Passage en NetworkFirst avec un délai réseau de 3 secondes : données fraîches en ligne, dernière réponse connue servie hors ligne ou sur réseau trop lent, consultation hors ligne préservée.

Ajoute deux tests de non-régression sur le flux de création client, vérifiés en échec lorsque la resynchronisation est retirée.

Closes #29